### PR TITLE
Remove invalid/unused _method and _version fields from payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Edit require_once autoload in example_autoload.php in line 33 to:
 Run HelloWorld ping to myallocator:
 
     root@nate:/var/www/project# php example_autoload.php
-    {"Auth" : "true", hello" : "world", "_method" : "HelloWorld", "_version" : "201408"}
+    {"Auth" : "true", hello" : "world"}
 
 #### Installation and usage example with manual installation:
 
@@ -105,7 +105,7 @@ Edit require_once autoload in example_autoload.php in line 33 to:
 Run HelloWorld ping to myallocator:
 
     root@nate:/var/www/project# php example_autoload.php
-    {"Auth" : "true", hello" : "world", "_method" : "HelloWorld", "_version" : "201408"}
+    {"Auth" : "true", hello" : "world"}
 
 #### Simple usage example:
 

--- a/src/MyAllocator/Api/MaApi.php
+++ b/src/MyAllocator/Api/MaApi.php
@@ -244,9 +244,6 @@ class MaApi extends MaBaseClass
                 if ($this->config['paramValidationEnabled']) {
                     $params_decoded = json_decode($params, TRUE);//params are array, why do this?
                     $params_decoded = $this->validateApiParameters($this->keys, $params_decoded);
-                    // Add URI method and version to payload
-                    $params['_method'] = $this->id;
-                    $params['_version'] = $requestor->version;
                     $params = json_encode($params_decoded);
                 }
                 break;
@@ -257,9 +254,6 @@ class MaApi extends MaBaseClass
                 } else {
                     $params = $this->setAuthenticationParametersNoValidation($params);
                 }
-                // Add URI method and version to payload
-                $params['_method'] = $this->id;
-                $params['_version'] = $requestor->version;
                 break;
             default:
                 throw new ApiException(

--- a/src/MyAllocator/Util/Requestor.php
+++ b/src/MyAllocator/Util/Requestor.php
@@ -120,7 +120,7 @@ class Requestor extends MaBaseClass
             /** @noinspection PhpMissingBreakStatementInspection */
             case 'array':
                 // Set data method
-                $this->state['method'] = $params['_method'];
+                $this->state['method'] = $method;
                 // Encode parameters
                 $this->debug_print_r($params); 
                 try {


### PR DESCRIPTION
Those fields are not part of our official API and are neither used nor needed. They will get in the way of validating allowed inputs.